### PR TITLE
$_SERVER headers incorrectly read due to uppercase/lowercase mixup

### DIFF
--- a/src/php/Apix/Request.php
+++ b/src/php/Apix/Request.php
@@ -256,7 +256,6 @@ class Request
             #$headers = http_get_request_headers();
             $headers = $_SERVER;
         }
-		
         $this->headers = array_change_key_case($headers);
     }
 


### PR DESCRIPTION
When a Request object is created, the headers are set from $_SERVER.  All of the keys in $_SERVER are set to uppercase.  However, all other interactions with headers in Request assume, and force, lowercase.  This was preventing POST data from being read, since HttpRequest->getBodyData() is looking for the 'CONTENT_TYPE' header to determine how to decode data.  Simple one-line fix to force the $_SERVER keys to lowercase.
